### PR TITLE
[FIX] 배포 후 확인 사항 수정

### DIFF
--- a/src/components/chat/chatlist/ChatRooms.tsx
+++ b/src/components/chat/chatlist/ChatRooms.tsx
@@ -1,39 +1,24 @@
 import { styled } from 'styled-components'
 import { ChatRoom } from 'components/index'
+import { useState, useEffect } from 'react'
+
 export const ChatRooms = () => {
+  const [innerHeight, setInnerHeight] = useState<number>(0)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setInnerHeight(window.innerHeight)
+    }
+  }, [])
+
   return (
-    <Wrapper>
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
-      <ChatRoom />
+    <Wrapper innerHeight={innerHeight}>
       <ChatRoom />
     </Wrapper>
   )
 }
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ innerHeight?: number }>`
   min-width: 375px;
-  min-height: calc(100vh - 199px);
+  height: ${props => props.innerHeight}px;
+  overflow: scroll;
 `

--- a/src/components/chat/chaton/ChatField.tsx
+++ b/src/components/chat/chaton/ChatField.tsx
@@ -1,9 +1,17 @@
 import React from 'react'
 import { useRecoilState } from 'recoil'
 import { msgActionsState } from 'recoil/index'
+import { useState, useEffect } from 'react'
 import { Wrapper, Sender, Recipient } from 'components/index'
 
 export const ChatField = ({ messages }) => {
+  const [innerHeight, setInnerHeight] = useState<number>(0)
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setInnerHeight(window.innerHeight)
+    }
+  }, [])
+
   //시간 로직 => 유틸 분리 가능?
   const shouldDisplayTimestamp = (currentMessage, nextMessage) => {
     if (!nextMessage) return true // Display timestamp for the last message
@@ -26,7 +34,7 @@ export const ChatField = ({ messages }) => {
   }
 
   return (
-    <Wrapper>
+    <Wrapper innerHeight={innerHeight}>
       {messages.map((message, index) => {
         //시간 로직
         const nextMessage = messages[index + 1]

--- a/src/components/chat/chaton/ChatInput.tsx
+++ b/src/components/chat/chaton/ChatInput.tsx
@@ -1,27 +1,26 @@
 import { styled } from 'styled-components'
-import { useRef } from 'react'
+import { useRef, useEffect } from 'react'
 
 export const ChatInput = () => {
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
-  //해당 로직들 input이 아니라 화면으로 적용?
-  // useEffect(() => {
-  //   handleResizeHeight()
-  // }, [])
+  useEffect(() => {
+    handleResizeHeight()
+  }, [])
 
-  // const handleResizeHeight = () => {
-  //   if (inputRef?.current) {
-  //     inputRef.current.style.height = 'auto' //height 초기화
-  //     inputRef.current.style.height = inputRef?.current.scrollHeight + 'px'
-  //   }
-  // }
+  const handleResizeHeight = () => {
+    if (inputRef?.current) {
+      inputRef.current.style.height = 'auto' //height 초기화
+      inputRef.current.style.height = inputRef?.current.scrollHeight + 'px'
+    }
+  }
 
   return (
     <>
       <StyledInput
         ref={inputRef}
         rows={1}
-        // onInput={handleResizeHeight}
+        onInput={handleResizeHeight}
       />
     </>
   )
@@ -34,6 +33,7 @@ const StyledInput = styled.textarea`
   border-radius: 21px;
   max-height: 114px;
   resize: none;
+  font-family: 'Pretendard', sans-serif;
   &:focus {
     outline: none;
   }

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -71,15 +71,5 @@ export const GlobalStyles = createGlobalStyle`
         url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-Bold.ttf') format("truetype");
     font-display: swap;
 }
-@font-face {
-    font-family: 'Pretendard';
-    font-weight: 800;
-    font-style: normal;
-    src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.eot');
-    src: url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.eot?#iefix') format('embedded-opentype'),
-        url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.woff2') format('woff2'),
-        url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.woff') format('woff'),
-        url('https://cdn.jsdelivr.net/gh/webfontworld/pretendard/Pretendard-ExtraBold.ttf') format("truetype");
-    font-display: swap;
-}
+
 `


### PR DESCRIPTION
1. textarea 내부 영문 폰트 적용
2. 채팅방 내부 인풋 모바일 뷰포트 상단바로 인해 레이아웃 오류발생, 중앙 영역 높이 맞춰 조절(자동배포 후 확인 필요) [참고](https://velog.io/@timosean/Web-%EB%AA%A8%EB%B0%94%EC%9D%BC-%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-100vh-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)
3. 인풋 높이조절 타입스크립트 오류 해결로 인한 주석처리, 주석 해제 후 로직 재설정