### PR TITLE
[FEAT] 메시지 공유 컴포넌트 타입 추가 및 공용 axios instances 파일 생성

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,29 @@
+import axios, { AxiosError, AxiosInstance } from 'axios'
+
+const authInterceptors = (instance: AxiosInstance): AxiosInstance => {
+  instance.interceptors.request.use(
+    config => {
+      // 로컬스토리지에 저장되어 있는 AccessToken을 호출.
+      const accessToken = localStorage.getItem('token')
+      if (config.headers && accessToken) {
+        // accessToken이 정상적으로 저장 => headers에 authorization 값을 추가.
+        config.headers.Authorization = `${accessToken}`
+      }
+      // authorization을 추가한 config 반환
+      return config
+    },
+    (error: AxiosError): Promise<AxiosError> => {
+      return Promise.reject(error)
+    }
+  )
+
+  return instance
+}
+
+// Authorization 설정이 없는 일반 사용자 API용 Instance
+export const baseInstance: AxiosInstance = axios.create({
+  baseURL: import.meta.env.VITE_BASE_URL
+})
+
+// Authorization 설정이 추가된 로그인한 사용자 API용 Instance --유저 API 에서 공통적으로 사용할 인스턴스
+export const authInstance: AxiosInstance = authInterceptors(baseInstance)

--- a/src/components/MediaQuery.tsx
+++ b/src/components/MediaQuery.tsx
@@ -27,5 +27,4 @@ const Wrapper = styled.div<{ $innerHeight?: number }>`
   justify-content: center;
   background-color: ${props => props.theme.greyScale.grey0};
   height: ${props => props.$innerHeight}px;
-  /* overflow: hidden; */
 `

--- a/src/components/chat/chaton/ChatField.tsx
+++ b/src/components/chat/chaton/ChatField.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useRecoilState } from 'recoil'
 import { msgActionsState } from 'recoil/index'
 import { useState, useLayoutEffect } from 'react'
-import { Wrapper, Sender, Recipient } from 'components/index'
+import { Wrapper, Sender, Recipient, SubjectDetail } from 'components/index'
 
 export const ChatField = ({ messages }) => {
   const [innerHeight, setInnerHeight] = useState<number>(0)
@@ -20,7 +20,6 @@ export const ChatField = ({ messages }) => {
     return false
   }
 
-  //atoms로 처리 후 Recipient && Sender에 존재하는 msgLayer 삭제
   //useOutsideClick으로 setOpenMsgActionsIndex(-1)로 초기화
   const [openMsgActionsIndex, setOpenMsgActionsIndex] =
     useRecoilState(msgActionsState)
@@ -47,7 +46,13 @@ export const ChatField = ({ messages }) => {
           <React.Fragment key={index}>
             {message.sender === 'sender' && (
               <Sender
-                message={message.text}
+                message={
+                  message.type === 'text' ? (
+                    message.text
+                  ) : (
+                    <SubjectDetail shared={true} />
+                  )
+                }
                 $sender={message.sender}
                 createdAt={message.createdAt}
                 showCreatedTime={showTimestamp}
@@ -57,7 +62,13 @@ export const ChatField = ({ messages }) => {
             )}
             {message.sender !== 'sender' && (
               <Recipient
-                message={message.text}
+                message={
+                  message.type === 'text' ? (
+                    message.text
+                  ) : (
+                    <SubjectDetail shared={true} />
+                  )
+                }
                 $sender={message.sender}
                 createdAt={message.createdAt}
                 showCreatedTime={showTimestamp}

--- a/src/components/chat/chaton/ChatInfo.tsx
+++ b/src/components/chat/chaton/ChatInfo.tsx
@@ -20,7 +20,7 @@ export const ChatInfo = () => {
     <InfoWrapper>
       <ChatSubject></ChatSubject>
       {/* isBuying(모임,상품정보) recoil값으로 전환 후 하단 계좌 컴포넌트 추가 렌더링  */}
-      {inDetail && <SubjectDetail />}
+      {inDetail && <SubjectDetail shared={false} />}
       {inDetail && isBuying && <AccountInfo isHost={true} />}
       <ChatAnn $registered={true}></ChatAnn>
     </InfoWrapper>

--- a/src/components/chat/chaton/SubjectDetail.tsx
+++ b/src/components/chat/chaton/SubjectDetail.tsx
@@ -3,11 +3,11 @@ import { isBuyingState } from 'recoil/index'
 import { useRecoilValue } from 'recoil'
 
 const price = 9000
-export const SubjectDetail = () => {
+export const SubjectDetail = ({ shared }) => {
   const isBuying = useRecoilValue(isBuyingState)
 
   return (
-    <Wrapper>
+    <Wrapper shared={shared}>
       <SubjectImg />
       <SubjectText>
         <SubjectTitle isBuying={isBuying}>
@@ -21,10 +21,11 @@ export const SubjectDetail = () => {
   )
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.div<{ shared: boolean }>`
   display: flex;
-  padding: 16px 24px;
-  background-color: ${props => props.theme.greyScale.bluegrey};
+  padding: ${props => (props.shared ? '0' : '16px 24px')};
+  background-color: ${props =>
+    props.shared ? '' : props.theme.greyScale.bluegrey};
 `
 const SubjectImg = styled.div`
   background-color: black;

--- a/src/constants/chat/chatTexts.ts
+++ b/src/constants/chat/chatTexts.ts
@@ -34,46 +34,74 @@ export const STATUS_TEXTS = {
 
 export const messages = [
   {
+    type: 'text',
     sender: 'sender',
     text: '보내는사람이매우긴메시지를보내는경우입니다띄어쓰기없이몇글자인지확인하실수있게안띄우고씁니다.근데이거길이제한은있어야할것같은데...',
     createdAt: '오후 10:23'
   },
-  { sender: 'sender', text: '안녕하세요', createdAt: '오후 10:28' },
-
-  { sender: 'sender', text: '안녕하세요', createdAt: '오후 10:28' },
   {
+    type: 'image',
+    sender: 'sender',
+    text: '안녕하세요',
+    createdAt: '오후 10:28'
+  },
+
+  {
+    type: 'text',
+    sender: 'sender',
+    text: '안녕하세요',
+    createdAt: '오후 10:28'
+  },
+  {
+    type: 'text',
     sender: 'sender',
     text: '10:28 같은 시간에 한번 더 안녕하세요. 시간이 보이지 않습니다. 근데 이러면 이렇게 너비를 풀로 차지하는 게 맞나......?',
     createdAt: '오후 10:28'
   },
-  { sender: 'sender', text: '안녕하세요', createdAt: '오후 10:49' },
   {
+    type: 'text',
+    sender: 'sender',
+    text: '안녕하세요',
+    createdAt: '오후 10:49'
+  },
+  {
+    type: 'text',
     sender: 'recipient',
     text: '다른사람이매우긴메시지를보내는경우입니다띄어쓰기없이몇글자인지확인하실수있게안띄우고씁니다.',
     createdAt: '오후 11:13'
   },
   {
+    type: 'image',
     sender: 'recipient',
     text: '다른 사람이 메세지를 연속적으로 보냈을 때 오후 11:23 같은 시간이 보이지 않습니다.',
     createdAt: '오후 11:23'
   },
   {
+    type: 'text',
     sender: 'recipient',
     text: '다른 사람이 메세지를 연속적으로 보냈을 때 오후 11:23 같은 시간이 보이지 않습니다.',
     createdAt: '오후 11:23'
   },
   {
+    type: 'text',
     sender: 'recipient',
     text: '다른 사람이 메세지를 연속적으로 보냈을 때 프로필사진이 보이지 않습니다.',
     createdAt: '오후 11:23'
   },
-  { sender: 'sender', text: '아 시간 조건 까다롭네', createdAt: '오후 11:25' },
   {
+    type: 'text',
+    sender: 'sender',
+    text: '아 시간 조건 까다롭네',
+    createdAt: '오후 11:25'
+  },
+  {
+    type: 'text',
     sender: 'recipient',
     text: '오후 11:47에 다른 사람이 안녕하세요',
     createdAt: '오후 11:47'
   },
   {
+    type: 'text',
     sender: 'sender',
     text: '오후 11:47에 내가 같은 시간에 한번 더 안녕하세요를 입력할 때는 다른 사람이 보냈으므로 시간이 나타납니다.',
     createdAt: '오후 11:47'


### PR DESCRIPTION
1. axios 사용시에 토큰값 필요한 유저 페이지 및 채팅은 authInstance import하셔서 사용하시면 됩니다. 현재 기준은 localStorage로 설정되어있는데 확인 후 쿠키사용시 로직변경이 필요할 것 같습니다.
2. 채팅 페이지에서 타입에 따라 일반 텍스트/공유 페이지 정보를 나눠 렌더링할 수 있도록 변경했습니다.