### PR TITLE
[FIX]: 성장해요 api 연동

### DIFF
--- a/src/api/mypage/mypageApi.ts
+++ b/src/api/mypage/mypageApi.ts
@@ -5,7 +5,7 @@ export async function getMyPage(memberId) {
   const apiUrl = import.meta.env.VITE_BASE_URL; 
 
   try {
-    const response = await authInstance.get(`${apiUrl}/api/mypage/${memberId}`);
+    const response = await authInstance.get(`${apiUrl}api/mypage/${memberId}`);
 
     return response.data;
   } catch (error) {

--- a/src/components/career/create/ifEmptyUserInfo/ProfileEnterWrap.tsx
+++ b/src/components/career/create/ifEmptyUserInfo/ProfileEnterWrap.tsx
@@ -7,8 +7,12 @@ import { ArrowLeft2 } from 'iconsax-react'
 export const ProfileEnterWrap = () => {
   const navigate = useNavigate()
 
+  const moveToProfile = () => {
+    navigate('/modifyprofile')
+  }
+
   const onClickHandler = () => {
-    navigate(-1)
+    navigate('/career')
   }
 
   return (
@@ -37,6 +41,7 @@ export const ProfileEnterWrap = () => {
       <Wrapper>
         <BtnWrap>
           <Button
+            onClick={moveToProfile}
             $btnWidth="100%"
             $btnHeight="60px"
             $fontSize="20px"

--- a/src/components/career/main/CareerMainItemCreateButton.tsx
+++ b/src/components/career/main/CareerMainItemCreateButton.tsx
@@ -3,11 +3,10 @@ import styled from 'styled-components'
 import { BrushSquare } from 'iconsax-react'
 import { useNavigate } from 'react-router-dom'
 
-export const CareerMainItemCreateButton = () => {
-  const isProfile = true
+export const CareerMainItemCreateButton = ({ isProfile }) => {
   const naviage = useNavigate()
   const handleClickBtn = () => {
-    isProfile ? naviage('/create/1') : naviage('/profile/1')
+    isProfile ? naviage('/create/1') : naviage('/profile')
   }
   return (
     <>
@@ -30,7 +29,7 @@ export const CareerMainItemCreateButton = () => {
 // 버튼 위치 조절 스타일러
 const BtnLocationChangeDiv = styled.div`
   position: fixed;
-  top: 82%;
+  top: 80%;
   z-index: 1;
   margin-left: 270px;
   transition: 0.3s;
@@ -43,12 +42,7 @@ const BtnLocationChangeDiv = styled.div`
 
   @media (max-width: 390px) {
     margin-left: 60%;
-    top: 83%;
-    transition: 0.3s;
-  }
-  @media (max-width: 391px) {
-    margin-left: 60%;
-    top: 78%;
+    top: 77%;
     transition: 0.3s;
   }
 
@@ -60,7 +54,7 @@ const BtnLocationChangeDiv = styled.div`
 
   @media (max-width: 325px) {
     margin-left: 55%;
-    top: 68%;
+    top: 70%;
     transition: 0.3s;
   }
 `

--- a/src/components/career/main/CareerMainItemImage.tsx
+++ b/src/components/career/main/CareerMainItemImage.tsx
@@ -1,6 +1,6 @@
 import { styled } from 'styled-components'
 interface PreviewImgProps {
-  image: string[]
+  $image: string[]
 }
 export const CareerMainItemImage = ({ image, remainingSeats }) => {
   const renderRemain = () => {
@@ -20,7 +20,7 @@ export const CareerMainItemImage = ({ image, remainingSeats }) => {
   }
   return (
     <Wrapper>
-      <PreviewImg image={image}>
+      <PreviewImg $image={image}>
         <RemainSpaces>{renderRemain()}</RemainSpaces>
       </PreviewImg>
     </Wrapper>
@@ -40,7 +40,7 @@ const PreviewImg = styled.div<PreviewImgProps>`
   width: 100px;
   height: 100px;
   border-radius: 8px;
-  background-image: ${props => `url(${props.image})`};
+  background-image: ${props => `url(${props.$image})`};
   background-size: 100% 100%;
   font-size: ${props => props.theme.customSize.medium};
   justify-content: flex-end;

--- a/src/components/career/paricipate/confirm/CareerMeetingStandby.tsx
+++ b/src/components/career/paricipate/confirm/CareerMeetingStandby.tsx
@@ -9,7 +9,7 @@ import styled from 'styled-components'
 export const CareerMeetingStandby = () => {
   const [letter, setLetter] = useState<{ [key: string]: boolean }>({})
   const [list, setList] = useRecoilState(paricipateListAtom)
-  const meetingId = String(48)
+  const meetingId = String(45)
 
   useEffect(() => {
     const fetchList = async () => {
@@ -22,6 +22,8 @@ export const CareerMeetingStandby = () => {
     }
     fetchList()
   }, [meetingId])
+
+  console.log(list)
 
   const handleToggle = (itemId: string) => {
     setLetter(prevLetter => ({

--- a/src/components/career/paricipate/getDetail/GetDetailCard.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailCard.tsx
@@ -37,12 +37,14 @@ export const GetDetailCard = () => {
   const roomAdminId = meetingRes.meetingMemberDto.id // 게시글 글쓴이 id
   const loggedInUser = decoder()?.memberId // 현재 로그인한 유저 id
   const isAdmin = loggedInUser === roomAdminId // 글쓴이 === 로그인한 유저
-
   const navigate = useNavigate()
 
-  if (!detailid && !loggedInUser) {
-    navigate('/career')
-  }
+  useEffect(() => {
+    if (!loggedInUser) {
+      navigate('/')
+    }
+  }, [loggedInUser])
+
   useEffect(() => {
     const fetchDetailData = async () => {
       if (detailid) {
@@ -56,7 +58,6 @@ export const GetDetailCard = () => {
           setMeetingRes(meetingResponse.response)
           setIsLoading(false)
         }
-
         if (memberResponse.status === 200) {
           setMemberRes(memberResponse.response)
         }
@@ -96,6 +97,10 @@ export const GetDetailCard = () => {
   }
 
   const renderFooter = () => {
+    if (isLoading) {
+      return 
+    }
+
     return isAdmin ? (
       <GetDetailFooterAndButtonHost loggedInUser={loggedInUser} />
     ) : (

--- a/src/components/career/paricipate/getDetail/GetDetailFooterAndButtonGuest.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailFooterAndButtonGuest.tsx
@@ -21,6 +21,10 @@ export const GetDetailFooterAndButtonGuest = ({ loggedInUser }) => {
   const remainingSeats: number = headCount - +recruitedPersonnel
 
   if (!detailid) {
+    return null
+  }
+
+  if (!detailid) {
     return
   }
 
@@ -122,7 +126,7 @@ export const GetDetailFooterAndButtonGuest = ({ loggedInUser }) => {
           <UseButtons
             modalState={useModal}
             onLeftClick={() => setUseModal(false)}
-            onRightClick={() => alert('메세지 보내기 구현 미완')}
+            onRightClick={() => navigate('/chatlist/p')}
             leftBtn={modalText[2]}
             rightBtn={modalText[3]}
           />
@@ -131,6 +135,27 @@ export const GetDetailFooterAndButtonGuest = ({ loggedInUser }) => {
     </>
   )
 }
+
+const Wrapper = styled.footer`
+  display: flex;
+  align-items: center;
+  position: sticky;
+  width: 100%;
+  max-width: 430px;
+  min-height: 80px;
+  z-index: 100;
+  bottom: 0%;
+  background-color: ${props => props.theme.main.white};
+  box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.2);
+`
+
+const BtnWrap = styled.div`
+  font-size: 20px;
+  line-height: 26px;
+  font-weight: 500;
+  width: 100%;
+  margin: 0 24px;
+`
 
 const IsUserNotJoined = styled.div`
   z-index: 100;
@@ -146,25 +171,4 @@ const IsUserNotJoined = styled.div`
   background-color: ${props => props.theme.greyScale.grey7};
   opacity: 0.9;
   color: ${props => props.theme.main.white};
-`
-
-const Wrapper = styled.footer`
-  display: flex;
-  align-items: center;
-  position: sticky;
-  width: 100%;
-  max-width: 430px;
-  min-height: 80px;
-  z-index: 100;
-  bottom: 0;
-  background-color: ${props => props.theme.main.white};
-  box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.2);
-`
-
-const BtnWrap = styled.div`
-  font-size: 20px;
-  line-height: 26px;
-  font-weight: 500;
-  width: 100%;
-  margin: 0 24px;
 `

--- a/src/components/career/paricipate/getDetail/GetDetailFooterAndButtonHost.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailFooterAndButtonHost.tsx
@@ -87,7 +87,7 @@ const Wrapper = styled.footer`
   max-width: 430px;
   min-height: 80px;
   z-index: 100;
-  bottom: 0;
+  bottom: 0%;
   background-color: ${props => props.theme.main.white};
   box-shadow: 0px -1px 1px rgba(0, 0, 0, 0.2);
 `

--- a/src/components/career/paricipate/getDetail/GetDetailManagerInfo.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailManagerInfo.tsx
@@ -1,21 +1,44 @@
+import { followAdd, followDelete } from '@/api'
 import { Button } from '@/components'
 import { fetchDetailGlobalState } from '@/recoil'
 import { useEffect, useState } from 'react'
 import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
 
+const initailFormData = {
+  nickname: 'nickname',
+  bio: 'bio',
+  followingId: 0,
+  image: null
+}
 export const GetDetailManagerInfo = () => {
+  const [isFollow, setIsFollow] = useState(false)
   const atom = useRecoilValue(fetchDetailGlobalState)
   const { meetingMemberDto } = atom
-  const [isFollow, setIsFollow] = useState(false)
-  const managerName = meetingMemberDto?.nickname || ''
-  const managerIntroduce = meetingMemberDto?.bio || ''
+  const { nickname, bio, id, image } = meetingMemberDto
+  const [profile, setProfile] = useState(initailFormData)
 
-  useEffect(() => {}, [managerName, managerIntroduce])
+  useEffect(() => {
+    setProfile({
+      nickname: nickname,
+      bio: bio,
+      followingId: id,
+      image: image
+    })
+  }, [meetingMemberDto])
 
-  // 대충 구현만 한거고 실제 사용시에는 클릭시마다 api호출 필요할듯
-  const handleFollow = () => {
-    setIsFollow(!isFollow)
+  const handleFollow = async () => {
+    if (isFollow) {
+      const deleteRes = await followDelete(id)
+      if (deleteRes.status === 200) {
+        setIsFollow(!isFollow)
+      }
+    } else {
+      const addRes = await followAdd(id, profile)
+      if (addRes.status === 200) {
+        setIsFollow(!isFollow)
+      }
+    }
   }
 
   const truncateText = (text: string, maxLength: number) => {
@@ -48,11 +71,11 @@ export const GetDetailManagerInfo = () => {
   return (
     <>
       <Container>
-        <RoomManagerImage />
+        {image && <RoomManagerImage src={image} />}
         <NameAndIntroduceWrap_Column>
-          <RoomManagerName>{managerName}</RoomManagerName>
+          <RoomManagerName>{nickname || ''}</RoomManagerName>
           <RoomManagerIntroduce>
-            {truncateText(managerIntroduce, 12)}
+            {truncateText(bio, 12) || ''}
           </RoomManagerIntroduce>
         </NameAndIntroduceWrap_Column>
         <FollowBtn>{checkFollow(isFollow)}</FollowBtn>
@@ -70,7 +93,7 @@ const Container = styled.div`
   align-items: center;
   gap: 8px;
 `
-const RoomManagerImage = styled.div`
+const RoomManagerImage = styled.img`
   background-color: ${props => props.theme.greyScale.grey5};
   border-radius: 8px;
   width: 52px;

--- a/src/components/career/paricipate/getDetail/GetDetailMemberSeeMore.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailMemberSeeMore.tsx
@@ -1,18 +1,27 @@
 //
+// import { followAdd } from '@/api'
 import { Button, Header } from '@/components'
 import { fetchDetailMemberState } from '@/recoil'
 import { ArrowLeft2 } from 'iconsax-react'
+import { useEffect } from 'react'
 // import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useLocation, useNavigate } from 'react-router-dom'
 import { useRecoilValue } from 'recoil'
 import styled from 'styled-components'
 export const GetDetailMemberSeeMore = () => {
-  const navigate = useNavigate()
   const memeberAtom = useRecoilValue(fetchDetailMemberState)
 
-  if (!memeberAtom) {
-    return
+  const location = useLocation()
+  const navigate = useNavigate()
+  const detailId = location.state.detailid
+
+  if (!detailId) {
+    console.log(detailId)
   }
+
+  useEffect(() => {
+    // const fetchData = async () => {}
+  }, [])
 
   const longText = (text, maxLength) => {
     return text.length > maxLength ? text.slice(0, maxLength) + '...' : text
@@ -36,7 +45,7 @@ export const GetDetailMemberSeeMore = () => {
             <MemberImage
               src={
                 member.image ??
-                'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAOEAAADhCAMAAAAJbSJIAAAAk1BMVEX33x4AAAD/5x/95B+klBRjWgz64h7/6R9dVAv85B/03B6bjBPizBv23h58cA/Ouhm0ohZORgnaxRpVTQofHATs1R1JQgnBrheGeRDGsxi6qBcsKAWMfhFSSgrArRczLgZzaA4jIAStnBWThRJqYA0aFwPcxxsSEAJCOwjo0RyhkhNwZQ0XFQMuKgU5MweCdRAMCwGYeiDHAAAHAUlEQVR4nO2caXuyOhCGIbGJAVosaqvUWpdudv//v+5A7VsVJhuCSa8z99dimocMk2QykyBAEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARBEARB5DAmCOFbCKGUue4QQNHDOkYdZZSwLF9fDO+Wo9Hy5nm4mA2ygAjPVIrZsF9jmOt7KXjSG4Z1buOMiBN03BjSB3oZvlDdz85Xz9APv3mLx2ZWcBLIGdTHnlohiWZSeVsuNuREArQ0UMhErNFXMol0dnAi7BWSxzsDgQUpP50MBdYKSc9MX8HaC0u1VUgujAWG4b0PTtVSoQBdr5ShBy7VTiH8tIJb9+7GSiG3MdEt986/RRuFZGUtMAxnrj2qhUKWNBAYhnPHhmqhkF81UhiO3bobc4V03kxgOHRrp+YKxXtDheHAqZ0aK2TXTQUWdupA2C/GCvltY4GxA107TBWyjVzB+2Kynr3K1uOXidsp0VQhfZEIeFuNOaGCEh7l0KZ4xR2v3EwVEomRXgS71TXlg+qf+2PnyzZTheewwPhwJhDjQ4ebux7AwFghS0GBr9WpjgV7lro4dz6AgbFCWrO/b6Jaeyz6+vnb09T1inSLqUIw9HQBeEmWbf82YT4MYGCsEN7az6GvjJRxqndPgjSBucJ76LEE9CPkI1x7FN43VQhGLzagDpZmzre9e3SgMGD+DGBwpJWmXkmRcJSn0QT//cB0tviEHrvyxmEqMFUIH1X8BTM1XbXloMKbwH+JpgozUGE49O3Et86Re4vwY+zD2YQK4/3hpUSiFzskFaYKFaeit5nXGo3jNJIP8Zv7zKNz+yrmsbalQmI4nHJfZ39jhdJQ1A/LXuTnQJrHvCO1woLZ2McP0lwh0WWYFJylfmULlVicPcmmxAM+BsSzD9JCoSQaVeWhd+7TBtjuDNg0TWHtS7ZQidU5/m+kUEvsS6TNUiF7NFVYHhp64lftsk3o1Fzic+bH/tgyY4jYHHX/qaj+7nmLUQwffIgLW2fuieTBQuOn+x2yffYli2xy2y4j1xKb5AhzzSL8gKfN38kY2vtRYpO2AJ9unIxGCgPG5xZfoyT4fyKaKSwcDjNJ9t4ycvotNlVY/HI8MZV46XIp3lxhWZSwNlyousz4PkZhsYoLVksjiY/u7PQ4hWVx0NRkerxyN4jHKiz8KkkMPsips0E8XmGpMVjd6AbR2Qq1DYUFVMzllV7fZK4GsSWF5SIgVZYqQLk3J6E1haWxPiqczlfrXTekRYXf4yhPlXZ1XtyqwrJyVho3jh3tMVpWWGytZPngfUcfYusKAwInaoaho/mifYXS4qHz1jpt1532FQYcnhodzYhdKJRU1zhyptYKGasnBleBjxrBbNT2kLUOn7asZKeAjKTLhdZlENBMpY22AWOycBCcRbKS1ZBuyiFPtfcRNLvGoDnFUmM5kp1EjKDOXIPvgwbb6Vy7AINNv7spn47L5NAePOEKqC/gbo7xwdPPn880dgrXSHWVq8noz/QEFjpK0mQAx86zvY9rrZbIwEY7KtLbdawP9YrC9wfU3CWNDlNoB6olmKT8pJPZQux3DHqHksrXSl9Y/UUMFKPI4Ry4DqJRrLJ+qvtTiZEexjcZnwIxihepRCLJaGjfSA++nJJ67Fnytj/3FZIE3tcuJEf1spX3R9srbxHVk8/fK7VyfA135sCepYG00TWQ5sU4nE1cvLZ2x5BxeIE/3cvLotIsp31zporIxDDlhyegjG9eZQ/Dc2xjgVUD3XVqGnAqhCAkkoarb/btSVUeW4xjnLHvEtKiTcKja7AsY4t+OWsDXcj/09PlZB2vXz/kT6wP7EmXz/Zw+RmvBoNefKG8kaDlCzLYWN0rNZX5ni2Paewfbc+GJomEMp4rb1sygdtx13qUBl44GZHXSoIkLteGdv1MiZA5bS0P9W0cga6es6KLM1IiddsacmCjer48UmE32Qrgzk/LFXg1jXLK0BN3EitteGEO/LYbNvbDWUfBYGGTgvaPlaQzbNPMJEreu9EXyBf5CuTzMos0B4RS3jq8ZKh+T4WGW4U5MaJYKCn46DSbxipXUnuBnPULK+l3XPcsEt0B+x4LnUMQY7sr98La1SAdwALjW+RW+s4wkj/pG9rxfJLKfJ4qthE7rsyuAhLsxThh/2t1okooRgZaUx3lxp0RbGD0ym5WwelOfYWYKxNCn3Nqc6YgSKo1/fspPe2pNuNJLNmg3sWJde0gI3Q6kV5F+7CYBw4q9Rgl4+tJxRfeTvINbZZsXraXvrxWlgFf/VmeMHeFiEWvOEvS9DrP82maUE7oUbNV2R4Xm6xscZqm2YYc22IrsF98bRBBEARBEARBEAT5n/EfVqVYu543+OgAAAAASUVORK5CYII='
+                'https://image.winudf.com/v2/image1/Y29tLmxpdmFibGUub2ZmaWNlbmVyX2ljb25fMTY2MzIwMDg2NV8wMzg/icon.png?w=184&fakeurl=1'
               }
               alt="멤버 이미지"
             />
@@ -94,7 +103,7 @@ const MembersContainer = styled.div`
   border-radius: 8px;
 `
 
-const StyledIcon = styled.button`
+const StyledIcon = styled.div`
   color: #000;
   font-size: ${props => props.theme.customSize.xxlarge};
 `

--- a/src/components/career/paricipate/getDetail/GetDetailMembersInfo.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailMembersInfo.tsx
@@ -1,19 +1,19 @@
 import { useState } from 'react'
 import { CareerCreateMeetingCommonQuestion } from '../..'
 import styled from 'styled-components'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { CommonAddIcon } from '@/components'
 import { useRecoilValue } from 'recoil'
 import { fetchDetailGlobalState, fetchDetailMemberState } from '@/recoil'
 
 export const GetDetailMembersInfo = ({ isAdmin }) => {
   const navigate = useNavigate()
+  const { detailid } = useParams()
   const [showMessage, setShowMessage] = useState(false)
   const memberAtom = useRecoilValue(fetchDetailMemberState)
   const meetingRes = useRecoilValue(fetchDetailGlobalState)
   const { msg } = meetingRes
   const isUserJoined = msg === '참여하고 있지않은 모임입니다.' ? false : true
-
   const maxLength = 20
 
   const longText = (text: string, maxLength: number) => {
@@ -24,7 +24,7 @@ export const GetDetailMembersInfo = ({ isAdmin }) => {
 
   const handleSeeMoreClick = () => {
     if (isUserJoined || isAdmin) {
-      navigate('members')
+      navigate(`/detail/${detailid}/members`, { state: detailid })
     } else {
       setShowMessage(true)
       setTimeout(() => {

--- a/src/components/career/paricipate/getDetail/GetDetailSimilarMeetupInfo.tsx
+++ b/src/components/career/paricipate/getDetail/GetDetailSimilarMeetupInfo.tsx
@@ -111,6 +111,18 @@ const CardCategoryChip = styled.div`
   border-radius: 4px;
   white-space: nowrap;
   overflow-x: auto;
+
+  @media screen and (max-width: 320px) {
+    & {
+      font-size: 10px;
+    }
+  }
+
+  @media screen and (max-width: 375px) {
+    & {
+      font-size: 12px;
+    }
+  }
 `
 
 const CardTitle = styled.div`

--- a/src/components/signin/SignInField.tsx
+++ b/src/components/signin/SignInField.tsx
@@ -16,21 +16,17 @@ export const SignInField = () => {
   const passwordRegex = SIGNIN_REGEX_TEXT.pwdCondition
   const isValidEmail = emailRegex.test(email)
   const isValidPassword = passwordRegex.test(password)
-  const navigate = useNavigate()
   const setTokenPayload = useSetRecoilState(tokenPayloadState)
-
   const handleEmailChange = e => setEmail(e.target.value)
   const handlePasswordChange = e => setPassword(e.target.value)
+  const navigate = useNavigate()
 
   const handleLogin = async () => {
     try {
       const response = await login(email, password)
-      // console.log('로그인 성공:', response);
-      // alert('로그인 성공 테스트 메세지');
-      if (response) {
-        navigate('/career')
-      }
-
+      console.log('로그인 성공:', response)
+      alert('로그인 성공')
+      navigate('/home')
       const decodedPayload = decoder()
       console.log('Decoded Token Payload:', decodedPayload)
 
@@ -39,7 +35,6 @@ export const SignInField = () => {
       console.error('로그인 실패:', error)
     }
   }
-
   const renderEmailErrorMessage = () => {
     if (!email) {
       return null

--- a/src/pages/CareerMeetingsCreate.tsx
+++ b/src/pages/CareerMeetingsCreate.tsx
@@ -33,6 +33,8 @@ export const CareerMeetingsCreate = () => {
   const blobImageFiles = file.file
   const { createstepid = '1' } = useParams<CareerUseParamsProps>()
 
+  console.log(dto)
+
   const handleNextStep = () => {
     const nextStep = parseInt(createstepid) + 1
     navigate(`/create/${nextStep}`)

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,51 +1,62 @@
-import { NAVIGATION_PATH } from "constants/index";
-import { Footer, Header, MyPageChatBtn } from "components/index";
-import { MyPageEditBtn, MyPageIntro, MyPagePostDisplay, MyPageSelectTab } from "components/index";
-import { Notification, Setting2 } from "iconsax-react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { css, styled } from "styled-components";
-import { useEffect, useState } from "react";
-import { myPageIntroProps } from "@/types";
-import { decoder } from "@/utils";
+import { NAVIGATION_PATH } from 'constants/index'
+import { Footer, Header, MyPageChatBtn } from 'components/index'
+import {
+  MyPageEditBtn,
+  MyPageIntro,
+  MyPagePostDisplay,
+  MyPageSelectTab
+} from 'components/index'
+import { Notification, Setting2 } from 'iconsax-react'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { css, styled } from 'styled-components'
+import { useEffect, useState } from 'react'
+import { myPageIntroProps } from '@/types'
+import { decoder } from '@/utils'
 
 export const MyPage = () => {
-  const navigate = useNavigate();
-  const location = useLocation();
+  const navigate = useNavigate()
+  const location = useLocation()
 
-  const decodedPayload = decoder();
-  console.log(decodedPayload.memberId);
-  const myPagePath = `/mypage/${decodedPayload.memberId}`;
+  const decodedPayload = decoder()
 
-useEffect(() => {
-  if (location.pathname === '/mypage/' || location.pathname === myPagePath) {
-    navigate('/mypage');
-  }
-}, [location.pathname, myPagePath]);
+  const myPagePath = `/mypage/${decodedPayload.memberId}`
 
-  const [userData, setUserData] = useState<myPageIntroProps | null>(null);
-  
+  useEffect(() => {
+    if (location.pathname === '/mypage/' || location.pathname === myPagePath) {
+      navigate('/mypage')
+    }
+  }, [location.pathname, myPagePath])
+
+  const [userData, setUserData] = useState<myPageIntroProps | null>(null)
+
   return (
-    <MyPageWrap>      
+    <MyPageWrap>
       <Header centerText="마이페이지">
         <StyledIcon>
-          <Link {...NAVIGATION_PATH.navigatorAlarm} >
-          <Notification />
+          <Link {...NAVIGATION_PATH.navigatorAlarm}>
+            <Notification />
           </Link>
         </StyledIcon>
         <IconWrapper>
           <Link {...NAVIGATION_PATH.navigatorSettingPage}>
-          <Setting2 />
+            <Setting2 />
           </Link>
         </IconWrapper>
       </Header>
-      <MyPageIntro userData={userData} setUserData={setUserData} />
+      <MyPageIntro
+        userData={userData}
+        setUserData={setUserData}
+      />
       <BtnWrap>
         <MyPageEditBtn userData={userData} />
-        <MyPageChatBtn/>
+        <MyPageChatBtn />
       </BtnWrap>
       <MyPageSelectTab />
-      <MyPagePostArea hide={userData?.response?.job === null && location.pathname === '/mypage'} >
-        <MyPagePostDisplay/>
+      <MyPagePostArea
+        hide={
+          userData?.response?.job === null && location.pathname === '/mypage'
+        }>
+        <MyPagePostDisplay />
       </MyPagePostArea>
       <Footer />
     </MyPageWrap>
@@ -60,31 +71,31 @@ const MyPageWrap = styled.div`
 
 const IconWrapper = styled.div`
   margin-left: 5px;
-  :visited{
+  :visited {
     color: inherit;
   }
-  :link{
+  :link {
     color: inherit;
   }
-    `
+`
 
 const StyledIcon = styled.div`
   margin-right: 5px;
-  :visited{
+  :visited {
     color: inherit;
   }
-  :link{
+  :link {
     color: inherit;
   }
 `
 
 const MyPagePostArea = styled.div<{ hide: boolean }>`
-    ${(props) =>
+  ${props =>
     props.hide &&
     css`
       opacity: 0;
     `}
-`;
+`
 
 const BtnWrap = styled.div`
   display: flex;

--- a/src/pages/Router.tsx
+++ b/src/pages/Router.tsx
@@ -74,7 +74,7 @@ export const routes = [
     errorElement: <ErrorComponent />,
     children: [
       generateRoute('/career', <CareerMain />),
-      generateRoute('/profile/:profileid', <CareerIsNotUserInfo />),
+      generateRoute('/profile', <CareerIsNotUserInfo />),
       generateRoute('/participate/confirm/:checkid', <CareerMeetingConfirm />),
       generateRoute('/create/:createstepid', <CareerMeetingsCreate />),
       generateRoute(


### PR DESCRIPTION
수정 사항

- 렌더링 시에 버튼 딸각거리며 동작하던 부분 수정 완료
- 글쓰기시에 간략프로필 미작성시에는 프로필 작성페이지로 이동
- 성장해요 메인에서 이미지 불러올때 콘솔창에 styled-component image 관련 경고 문구 해결
- 상세 페이지에서 팔로우 구현 완료, 단 조회로직 추가해야함
- 방장일때 모집인원이 0이면 자동으로 모집마감되고 api요청 막아뒀고 모집인원수가 0보다 크면 closing이면 reopen, !closing이면 open api연동되도록 수정
- 상세 페이지 매니저 이미지 추가