### PR TITLE
[FIX] 성장해요 메인 페이지 동적 UI 수정

### DIFF
--- a/src/components/career/main/CareerMainItemCategory.tsx
+++ b/src/components/career/main/CareerMainItemCategory.tsx
@@ -1,8 +1,18 @@
 import { styled } from 'styled-components'
 
-export const CareerMainItemCategory = ({ jobs }) => {
+interface CategoryItemProps {
+  $isGrey: boolean
+}
+
+export const CareerMainItemCategory = ({ jobs, remainingSeats }) => {
   const categoryChips = jobs.slice(0, 2).map((category, index) => {
-    return <CategoryItem key={index}>{category}</CategoryItem>
+    return (
+      <CategoryItem
+        key={index}
+        $isGrey={remainingSeats === 0}>
+        {category}
+      </CategoryItem>
+    )
   })
   return <CategoryWrap>{categoryChips}</CategoryWrap>
 }
@@ -19,10 +29,11 @@ const CategoryWrap = styled.div`
   }
 `
 
-const CategoryItem = styled.div`
+const CategoryItem = styled.div<CategoryItemProps>`
   width: auto;
   height: 25px;
-  color: ${props => props.theme.greyScale.grey7};
+  color: ${props =>
+    props.$isGrey ? props.theme.greyScale.grey4 : props.theme.greyScale.grey7};
   background-color: ${props => props.theme.greyScale.grey2};
   font-size: 14px;
   line-height: 16.71px;

--- a/src/components/career/main/CareerMainItemImage.tsx
+++ b/src/components/career/main/CareerMainItemImage.tsx
@@ -1,27 +1,35 @@
 import { styled } from 'styled-components'
 interface PreviewImgProps {
-  $image: string[]
+  $image?: string[]
+  $isNone?: boolean
+  $isOpacity?: boolean
 }
 export const CareerMainItemImage = ({ image, remainingSeats }) => {
   const renderRemain = () => {
-    if (remainingSeats === 0)
+    if (remainingSeats === 0) {
       return (
-        <>
-          <ImpactColor>마감되었습니다</ImpactColor>
-        </>
+        <RemainSpaces $isNone={true}>
+          <ImpactColor $isNone={true}>마감되었습니다</ImpactColor>
+        </RemainSpaces>
       )
-
-    return (
-      <>
-        <ImpactColor>{remainingSeats}자리</ImpactColor>
-        남았어요
-      </>
-    )
+    }
+    if (remainingSeats <= 2) {
+      return (
+        <RemainSpaces $isNone={false}>
+          <ImpactColor $isNone={false}>{remainingSeats}자리</ImpactColor>
+          남았어요
+        </RemainSpaces>
+      )
+    }
+    return
   }
+
   return (
     <Wrapper>
-      <PreviewImg $image={image}>
-        <RemainSpaces>{renderRemain()}</RemainSpaces>
+      <PreviewImg
+        $image={image}
+        $isOpacity={remainingSeats === 0}>
+        {renderRemain()}
       </PreviewImg>
     </Wrapper>
   )
@@ -45,9 +53,10 @@ const PreviewImg = styled.div<PreviewImgProps>`
   font-size: ${props => props.theme.customSize.medium};
   justify-content: flex-end;
   align-items: contain;
+  opacity: ${props => (props.$isOpacity ? 0.6 : 1)};
 `
 // 미리보기 아래 잔여 참여석
-const RemainSpaces = styled.div`
+const RemainSpaces = styled.div<PreviewImgProps>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -59,8 +68,10 @@ const RemainSpaces = styled.div`
   color: ${props => props.theme.main.white};
   background-color: ${props => props.theme.greyScale.grey8};
   gap: 2px;
+  display: ${props => (props.$isNone ? 'none' : 'span')};
 `
 // 미리보기 아래 잔여석 글자 강조색
-const ImpactColor = styled.p`
+const ImpactColor = styled.p<PreviewImgProps>`
   color: ${props => props.theme.subColor.redD2};
+  display: ${props => (props.$isNone ? 'none' : 'span')};
 `

--- a/src/components/career/main/CareerMainItemMeetingTime.tsx
+++ b/src/components/career/main/CareerMainItemMeetingTime.tsx
@@ -1,9 +1,13 @@
 import { styled } from 'styled-components'
+interface GreyProps {
+  $isGrey?: boolean
+}
 export const CareerMainItemMeetingTime = ({
   week,
   days,
   time,
-  progressTime
+  progressTime,
+  remainingSeats
 }) => {
   const fetchWeek = week
   const fetchDays = days
@@ -11,14 +15,15 @@ export const CareerMainItemMeetingTime = ({
   const fetchProgressTiem = progressTime
 
   return (
-    <MeetingTime>
+    <MeetingTime $isGrey={remainingSeats === 0}>
       {fetchWeek ? fetchWeek : ''} {fetchDays ? fetchDays : ''} {fetchTime}{' '}
       {fetchProgressTiem ? `${fetchProgressTiem}분` : '-'}
     </MeetingTime>
   )
 }
 
-const MeetingTime = styled.div`
-  color: ${props => props.theme.greyScale.grey6};
+const MeetingTime = styled.div<GreyProps>`
+  color: ${props =>
+    props.$isGrey ? props.theme.greyScale.grey3 : props.theme.greyScale.grey6};
   margin-bottom: -5px;
 `

--- a/src/components/career/main/CareerMainItemParticipantNRemainSpace.tsx
+++ b/src/components/career/main/CareerMainItemParticipantNRemainSpace.tsx
@@ -1,15 +1,20 @@
 import { styled } from 'styled-components'
+
+interface GreyProps {
+  $isGrey?: boolean
+}
 export const CareerMainItemParticipant = ({
   positions, // 직급
   recruitedPersonnel, // 모집된 인원수
-  headCount // 모집 인원수
+  headCount, // 모집 인원수
+  remainingSeats
 }) => {
   const fetchPositions = positions
   const fetchsubscription = recruitedPersonnel
   const fetchHeadCount = headCount
 
   return (
-    <ParticipantNRemainSpate>
+    <ParticipantNRemainSpate $isGrey={remainingSeats === 0}>
       {fetchPositions.join(' ') || '없음'} |{' '}
       {`${fetchsubscription}/${fetchHeadCount}`}명
     </ParticipantNRemainSpate>
@@ -17,6 +22,7 @@ export const CareerMainItemParticipant = ({
 }
 
 // 참여자 직급 | 잔여석
-const ParticipantNRemainSpate = styled.div`
-  color: ${props => props.theme.greyScale.grey6};
+const ParticipantNRemainSpate = styled.div<GreyProps>`
+  color: ${props =>
+    props.$isGrey ? props.theme.greyScale.grey3 : props.theme.greyScale.grey6};
 `

--- a/src/components/career/main/CareerMainItemTitle.tsx
+++ b/src/components/career/main/CareerMainItemTitle.tsx
@@ -1,11 +1,28 @@
+import { isGreyProps } from '@/types'
 import { styled } from 'styled-components'
-export const CareerMainItemTitle = ({ title }) => {
-  
-  return <Title>{title.length > 15 ? title.slice(0,10) + '...' : title || '없음'}</Title>
+
+export const CareerMainItemTitle = ({ title, remainingSeats }) => {
+  const renderContents = () => {
+    if (remainingSeats === 0) {
+      return (
+        <Title $isGrey={true}>
+          {title.length > 15 ? title.slice(0, 10) + '...' : title || '없음'}
+        </Title>
+      )
+    }
+    return (
+      <Title>
+        {title.length > 15 ? title.slice(0, 10) + '...' : title || '없음'}
+      </Title>
+    )
+  }
+
+  return renderContents()
 }
 
-const Title = styled.div`
-  color: ${props => props.theme.greyScale.grey9};
+const Title = styled.div<isGreyProps>`
+  color: ${props =>
+    props.$isGrey ? props.theme.greyScale.grey3 : props.theme.greyScale.grey9};
   font-size: ${props => props.theme.customSize.xlarge};
   font-weight: 600;
 `

--- a/src/components/career/main/CareerMainItemsWrap.tsx
+++ b/src/components/career/main/CareerMainItemsWrap.tsx
@@ -59,9 +59,16 @@ export const CareerMainItemsWrap = ({ data }: { data: CareerData }) => {
 
         <ItemFlexColumnWrapper>
           {/* 글 묶음 */}
-          <CareerMainItemCategory jobs={jobs} />
-          <CareerMainItemTitle title={title} />
+          <CareerMainItemCategory
+            jobs={jobs}
+            remainingSeats={remainingSeats}
+          />
+          <CareerMainItemTitle
+            title={title}
+            remainingSeats={remainingSeats}
+          />
           <CareerMainItemMeetingTime
+            remainingSeats={remainingSeats}
             week={week}
             days={days || '월요일'}
             time={time}
@@ -69,6 +76,7 @@ export const CareerMainItemsWrap = ({ data }: { data: CareerData }) => {
           />
 
           <CareerMainItemParticipant
+            remainingSeats={remainingSeats}
             positions={positions}
             recruitedPersonnel={recruitedPersonnel}
             headCount={headCount}

--- a/src/types/career/index.ts
+++ b/src/types/career/index.ts
@@ -6,4 +6,5 @@ export * from 'types/career/fetchMainResponseDataProps'
 export * from 'types/career/requestCreateResponseProps'
 export * from 'types/career/requestCreateResponseDataProps'
 export * from 'types/career/fetchMemberResponseProps'
+export * from 'types/career/isGreyProps'
 

--- a/src/types/career/isGreyProps.ts
+++ b/src/types/career/isGreyProps.ts
@@ -1,0 +1,3 @@
+export interface isGreyProps {
+  $isGrey?: boolean
+}


### PR DESCRIPTION
성장해요 메인페이지 디자인 수정
1. 마감된 모집일 시 강조 텍스트 제거
2. 마감된 모집일 시 텍스트 및 이미지 투명도, 명도 조절
3. 잔여 좌석 강조 텍스트 항상 노출에서 2자리 이하일때만 노출되도록 수정